### PR TITLE
Fix Remove XP button from edit public profile

### DIFF
--- a/packages/react-app/pages/profile/edit-public-profile.js
+++ b/packages/react-app/pages/profile/edit-public-profile.js
@@ -157,7 +157,7 @@ const EditPublicProfilePage = () => {
                       },
                     })}
                   />
-                  <Button bg="red.200" onClick={() => xpRemove()}>
+                  <Button bg="red.200" onClick={() => xpRemove(index)}>
                     Remove XP
                   </Button>
                 </HStack>


### PR DESCRIPTION
fixes #83 

Add index to avoid removing all the experiences when clicking one **Remove XP**.