### PR TITLE
Use local provider to get dev profiles

### DIFF
--- a/packages/react-app/pages/index.js
+++ b/packages/react-app/pages/index.js
@@ -118,10 +118,9 @@ function Home() {
   );
 
   const init = async () => {
-    if (context.injectedProvider && context.injectedProvider.getSigner()) {
+    if (context.localProvider) {
       try {
-        const signer = context.injectedProvider.getSigner();
-        const contract = await loadDRecruitV1Contract(context.targetNetwork, signer);
+        const contract = await loadDRecruitV1Contract(context.targetNetwork, context.localProvider);
         setDRecruitContract(contract);
         const lastTokenId = await contract.tokenId();
         const tokenIds = [...Array(parseInt(lastTokenId, 10)).keys()];


### PR DESCRIPTION
fixes #88 

Use the local provider to get developer profiles to display the profiles even if the user isn't logged in or connected with a wallet.