### PR TITLE
Revert "Use local provider to get dev profiles"

### DIFF
--- a/packages/react-app/pages/index.js
+++ b/packages/react-app/pages/index.js
@@ -118,9 +118,10 @@ function Home() {
   );
 
   const init = async () => {
-    if (context.localProvider) {
+    if (context.injectedProvider && context.injectedProvider.getSigner()) {
       try {
-        const contract = await loadDRecruitV1Contract(context.targetNetwork, context.localProvider);
+        const signer = context.injectedProvider.getSigner();
+        const contract = await loadDRecruitV1Contract(context.targetNetwork, signer);
         setDRecruitContract(contract);
         const lastTokenId = await contract.tokenId();
         const tokenIds = [...Array(parseInt(lastTokenId, 10)).keys()];


### PR DESCRIPTION
Reverts moonshotcollective/drecruit#90

This breaks the network detection and network switch behaviour. A PR to address this should also incorporate the external logic.